### PR TITLE
Crash when parsing a text contains "::"

### DIFF
--- a/SwiftIconFont/Classes/SwiftIconFont.swift
+++ b/SwiftIconFont/Classes/SwiftIconFont.swift
@@ -161,7 +161,7 @@ func getAttributedString(_ text: NSString, ofSize size: CGFloat) -> NSMutableAtt
     for substring in ((text as String).characters.split{$0 == " "}.map(String.init)) {
         var splitArr = ["", ""]
         splitArr = substring.characters.split{$0 == ":"}.map(String.init)
-        if splitArr.count == 1 {
+        if splitArr.count < 2 {
             continue
         }
         


### PR DESCRIPTION
Parsing a text contains double colon (::) crash as it creates an empty array.
Extended check of 'splitArr.count' to 'less than' 2 elements.